### PR TITLE
[IMP] account_statement_base: no need to depend on account_reconcile_model_oca tests

### DIFF
--- a/account_statement_base/tests/test_account_statement_base.py
+++ b/account_statement_base/tests/test_account_statement_base.py
@@ -1,16 +1,15 @@
 from odoo import Command
 from odoo.tests import tagged
 
-from odoo.addons.account_reconcile_model_oca.tests.common import (
-    TestAccountReconciliationCommon,
-)
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
 @tagged("post_install", "-at_install")
-class TestReconciliationWidget(TestAccountReconciliationCommon):
+class TestOpenEntries(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company = cls.company_data["company"]
         cls.acc_bank_stmt_model = cls.env["account.bank.statement"]
         cls.account_move_model = cls.env["account.move"]
         cls.account_move_line_model = cls.env["account.move.line"]


### PR DESCRIPTION
in 16.0, a PR was added to ["Link to Account Move Lines in Statements"](https://github.com/OCA/account-reconcile/pull/659)
it was forward ported to 17.0, which introduced a dep on `account_reconcile_model_oca` for tests.
this dependency is strictly needed and actually unwelcome in some contexts where we might want `accountant_statement-import` modules without `account_reconcile_model_oca`.
so this PR: will simplify the test, it will no longer have a dependency on `account_reconcile_model_oca`, making the modules in `accountant_statement-import ` depend on `account_statement_base` and will no longer have overlapping dependencies from `account_reconcile_model_oca`.